### PR TITLE
minor bug fix, new ip retrieval url, new ip= parameter for stand alone server.

### DIFF
--- a/cfg/whatismyip.txt
+++ b/cfg/whatismyip.txt
@@ -1,1 +1,1 @@
-http://automation.whatismyip.com/n09230945.asp
+http://ipv4.icanhazip.com

--- a/soundrts/servermain.py
+++ b/soundrts/servermain.py
@@ -132,6 +132,11 @@ class Server(asyncore.dispatcher):
     ip = ""
 
     def _get_ip_address(self):
+        for p in self.parameters:
+            if p.lower().startswith('ip='): self.ip=p.split('=')[1]
+        if self.ip and re.match("^[0-9.]{7,40}$", self.ip):
+            info('Using provided ip: %s', self.ip)
+            return
         try:
             self.ip = urllib.urlopen(WHATISMYIP_URL).read().strip()
             if not re.match("^[0-9.]{7,40}$", self.ip):

--- a/soundrts/worldentity.py
+++ b/soundrts/worldentity.py
@@ -169,7 +169,7 @@ class Entity(object):
                     player.send_event(self, event)
 
     def aim_range(self, a):
-        range = a.range
+        range = a.range or 0
         if a.is_ballistic and a.height > self.height:
             # each height difference has a bonus of 1
             bonus = (a.height - self.height) * PRECISION * 1


### PR DESCRIPTION
Updated ip retrieval url, and added ip=xxx.xxx.xxx.xxx parameter for stand alone server.
The old url http://automation.whatismyip.com/n09230945.asp hasn't been working for a while now.
Changed it to http://ipv4.icanhazip.com, which seems to work perfectly.
The ip= parameter will just use the ip supplied if it is valid, and not attempt to use any ip retrieval url. Only really useful in rare cases (LIKE MINE!) where the system running the server has multiple external ip addresses, and the one returned from the whatismyip service is not the one you want to have soundrts reporting to the metaserver.

Bug fixed: Aim range wasn't taking into account the possibility that a.range could be None if range value was left out of a soldier definition. None is now replaced with 0 in this case.
