### PR TITLE
Adds environment variables

### DIFF
--- a/soundrts/config.py
+++ b/soundrts/config.py
@@ -81,7 +81,12 @@ def _copy_to_module(c):
     error = False
     for section, option, default, converter in _options:
         try:
-            raw_value = c.get(section, option)
+            # Check if environment variable exists for this option
+            env_value = os.getenv(option.upper())
+            if env_value is not None:
+                raw_value = env_value
+            else:
+                raw_value = c.get(section, option)
         except configparser.Error:
             info("%r option is missing (will be: %r)", option, default)
             value = default


### PR DESCRIPTION
This change to the config module makes the function
first check if an environment variable is present,
and if not, the property is read from the config file as usual. This happens
in preparation for creating a Docker image.
