### PR TITLE
Fix meadow loss when upgrading to land-consuming buildings

### DIFF
--- a/soundrts/worldorders.py
+++ b/soundrts/worldorders.py
@@ -528,16 +528,20 @@ class UpgradeToOrder(ProductionOrder):
             self.unit.is_buildable_anywhere and not self.type.is_buildable_anywhere
         )
         blocked_exit = self.unit.blocked_exit
+        building_land = self.unit.building_land
         if consume_meadow:
             meadow = place.find_nearest_meadow(self.unit)
             if meadow:
                 x, y = meadow.x, meadow.y
+                building_land = meadow
                 meadow.delete()
             else:
                 self.unit.notify("order_impossible")
                 return
         self.unit.delete()
         unit = self.type(player, place, x, y)
+        if not unit.is_buildable_anywhere:
+            unit.building_land = building_land
         if blocked_exit:
             unit.block(blocked_exit)
         if hp != hp_max:


### PR DESCRIPTION
### Bug description

When a unit is upgraded into a building that consumes meadow land,
the meadow is removed from the world but not recorded in the new
building's `building_land` field.

As a result, when the upgraded building is destroyed, the meadow
cannot be restored and is permanently lost.

### Fix

This PR preserves or assigns `building_land` during the upgrade
process so that buildings created via `upgrade_to` correctly restore
their meadow when destroyed.

The fix is consistent with the normal building construction logic and
does not affect buildings that do not consume meadow.
I encountered this issue during gameplay and verified that this change fixes the problem.